### PR TITLE
feat: Standardizing audit fields across entities

### DIFF
--- a/src/BasisTheory.net.Tests/Applications/Helpers/ApplicationFactory.cs
+++ b/src/BasisTheory.net.Tests/Applications/Helpers/ApplicationFactory.cs
@@ -14,7 +14,9 @@ namespace BasisTheory.net.Tests.Applications.Helpers
             .RuleFor(a => a.Name, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.Key, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.Type, (f, _) => f.Lorem.Word())
+            .RuleFor(a => a.CreatedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(t => t.Permissions, (f, _) => f.Make(f.Random.Int(1, 5), () => f.Random.Word()));
 

--- a/src/BasisTheory.net.Tests/Atomic/Banks/Helpers/AtomicBankFactory.cs
+++ b/src/BasisTheory.net.Tests/Atomic/Banks/Helpers/AtomicBankFactory.cs
@@ -15,6 +15,8 @@ namespace BasisTheory.net.Tests.Atomic.Banks.Helpers
             .RuleFor(a => a.Type, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.CreatedBy, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(a => a.Bank, (_, _) => BankFaker.Generate())
             .RuleFor(a => a.Fingerprint, (f, _) => f.Lorem.Word())
             .RuleFor(t => t.Metadata, (f, _) =>

--- a/src/BasisTheory.net.Tests/Atomic/Cards/Helpers/AtomicCardFactory.cs
+++ b/src/BasisTheory.net.Tests/Atomic/Cards/Helpers/AtomicCardFactory.cs
@@ -15,6 +15,8 @@ namespace BasisTheory.net.Tests.Atomic.Cards.Helpers
             .RuleFor(a => a.Type, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.CreatedBy, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(a => a.Card, (_, _) => CardFaker.Generate())
             .RuleFor(a => a.Fingerprint, (f, _) => f.Lorem.Word())
             .RuleFor(t => t.Metadata, (f, _) =>

--- a/src/BasisTheory.net.Tests/ReactorFormulas/Helpers/ReactorFormulaFactory.cs
+++ b/src/BasisTheory.net.Tests/ReactorFormulas/Helpers/ReactorFormulaFactory.cs
@@ -17,7 +17,9 @@ namespace BasisTheory.net.Tests.ReactorFormulas.Helpers
             .RuleFor(a => a.SourceTokenType, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.Icon, (f, _) => f.Random.Hash())
             .RuleFor(a => a.Code, (f, _) => f.Lorem.Paragraph())
+            .RuleFor(a => a.CreatedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(t => t.Configuration, (f, _) =>
                 f.Make(f.Random.Int(1, 5), () => ReactorFormulaConfigurationFaker.Generate()))

--- a/src/BasisTheory.net.Tests/Reactors/Helpers/ReactorFactory.cs
+++ b/src/BasisTheory.net.Tests/Reactors/Helpers/ReactorFactory.cs
@@ -16,7 +16,9 @@ namespace BasisTheory.net.Tests.Reactors.Helpers
             .RuleFor(a => a.Name, (f, _) => f.Lorem.Word())
             .RuleFor(a => a.TenantId, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.ReactorFormula, (_, _) => ReactorFormulaFactory.ReactorFormula())
+            .RuleFor(a => a.CreatedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
             .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(t => t.Configuration, (f, model) =>
                 model.ReactorFormula.Configuration.Select(x => KeyValuePair.Create(x.Name, f.Lorem.Word()))

--- a/src/BasisTheory.net.Tests/Tenants/Helpers/TenantFactory.cs
+++ b/src/BasisTheory.net.Tests/Tenants/Helpers/TenantFactory.cs
@@ -10,8 +10,10 @@ namespace BasisTheory.net.Tests.Tenants.Helpers
             .RuleFor(a => a.Id, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.OwnerId, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.Name, (f, _) => f.Lorem.Word())
-            .RuleFor(a => a.CreatedDate, (_, _) => DateTimeOffset.UtcNow)
-            .RuleFor(a => a.ModifiedDate, (_, _) => DateTimeOffset.UtcNow);
+            .RuleFor(a => a.CreatedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset());
 
         public static Tenant Tenant(Action<Tenant> applyOverrides = null)
         {

--- a/src/BasisTheory.net.Tests/Tokens/Helpers/TokenFactory.cs
+++ b/src/BasisTheory.net.Tests/Tokens/Helpers/TokenFactory.cs
@@ -17,8 +17,10 @@ namespace BasisTheory.net.Tests.Tokens.Helpers
             .RuleFor(a => a.Type, _ => TokenTypes.Token)
             .RuleFor(a => a.Data, (f, _) => JsonUtility.SerializeObject(f.Random.Word()))
             .RuleFor(a => a.Fingerprint, (f, _) => f.Lorem.Word())
-            .RuleFor(a => a.CreatedBy, (_, _) => Guid.NewGuid())
-            .RuleFor(a => a.CreatedDate, (_, _) => DateTimeOffset.UtcNow)
+            .RuleFor(a => a.CreatedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.CreatedDate, (f, _) => f.Date.PastOffset())
+            .RuleFor(a => a.ModifiedBy, (f, _) => Guid.NewGuid())
+            .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(a => a.Encryption, (_, _) => EncryptionMetadataModelFaker.Generate())
             .RuleFor(t => t.Metadata, (f, _) =>
                 f.Make(f.Random.Int(1, 5), () => KeyValuePair.Create(f.Random.String(10, 20, 'A', 'Z'), f.Lorem.Word()))

--- a/src/BasisTheory.net/Applications/Entities/Application.cs
+++ b/src/BasisTheory.net/Applications/Entities/Application.cs
@@ -27,9 +27,17 @@ namespace BasisTheory.net.Applications.Entities
         [JsonPropertyName("type")]
         public string Type { get; set; }
 
+        [JsonProperty("created_by")]
+        [JsonPropertyName("created_by")]
+        public Guid? CreatedBy { get; set; }
+
         [JsonProperty("created_at")]
         [JsonPropertyName("created_at")]
-        public DateTimeOffset CreatedDate { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        [JsonProperty("modified_by")]
+        [JsonPropertyName("modified_by")]
+        public Guid? ModifiedBy { get; set; }
 
         [JsonProperty("modified_at")]
         [JsonPropertyName("modified_at")]

--- a/src/BasisTheory.net/ReactorFormulas/Entities/ReactorFormula.cs
+++ b/src/BasisTheory.net/ReactorFormulas/Entities/ReactorFormula.cs
@@ -43,9 +43,17 @@ namespace BasisTheory.net.ReactorFormulas.Entities
         [JsonPropertyName("request_parameters")]
         public List<ReactorFormulaRequestParameter> RequestParameters { get; set; }
 
+        [JsonProperty("created_by")]
+        [JsonPropertyName("created_by")]
+        public Guid? CreatedBy { get; set; }
+
         [JsonProperty("created_at")]
         [JsonPropertyName("created_at")]
-        public DateTimeOffset CreatedDate { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        [JsonProperty("modified_by")]
+        [JsonPropertyName("modified_by")]
+        public Guid? ModifiedBy { get; set; }
 
         [JsonProperty("modified_at")]
         [JsonPropertyName("modified_at")]

--- a/src/BasisTheory.net/Reactors/Entities/Reactor.cs
+++ b/src/BasisTheory.net/Reactors/Entities/Reactor.cs
@@ -28,9 +28,17 @@ namespace BasisTheory.net.Reactors.Entities
         [JsonPropertyName("configuration")]
         public Dictionary<string, string> Configuration { get; set; }
 
+        [JsonProperty("created_by")]
+        [JsonPropertyName("created_by")]
+        public Guid? CreatedBy { get; set; }
+
         [JsonProperty("created_at")]
         [JsonPropertyName("created_at")]
-        public DateTimeOffset CreatedDate { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        [JsonProperty("modified_by")]
+        [JsonPropertyName("modified_by")]
+        public Guid? ModifiedBy { get; set; }
 
         [JsonProperty("modified_at")]
         [JsonPropertyName("modified_at")]

--- a/src/BasisTheory.net/Tenants/Entities/Tenant.cs
+++ b/src/BasisTheory.net/Tenants/Entities/Tenant.cs
@@ -18,9 +18,17 @@ namespace BasisTheory.net.Tenants.Entities
         [JsonPropertyName("name")]
         public string Name { get; set; }
 
+        [JsonProperty("created_by")]
+        [JsonPropertyName("created_by")]
+        public Guid? CreatedBy { get; set; }
+
         [JsonProperty("created_at")]
         [JsonPropertyName("created_at")]
-        public DateTimeOffset CreatedDate { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        [JsonProperty("modified_by")]
+        [JsonPropertyName("modified_by")]
+        public Guid? ModifiedBy { get; set; }
 
         [JsonProperty("modified_at")]
         [JsonPropertyName("modified_at")]


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Standardizes on having nullable created_by, created_at, modified_by, modified_at fields on all auditable entities
- _Note: We will treat this as a feature, but this may be a breaking change for consumers expected audit fields to be non-null._

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
