### PR TITLE
feat: support sessions & remove expiring app property

### DIFF
--- a/src/BasisTheory.net.Tests/Applications/Helpers/ApplicationFactory.cs
+++ b/src/BasisTheory.net.Tests/Applications/Helpers/ApplicationFactory.cs
@@ -19,7 +19,6 @@ namespace BasisTheory.net.Tests.Applications.Helpers
             .RuleFor(a => a.ModifiedBy, (_, _) => Guid.NewGuid())
             .RuleFor(a => a.ModifiedDate, (f, _) => f.Date.PastOffset())
             .RuleFor(t => t.Permissions, (f, _) => f.Make(f.Random.Int(1, 5), () => f.Random.Word()))
-            .RuleFor(a => a.CanCreateExpiringApplications, (f, _) => f.Random.Bool())
             .RuleFor(a => a.ExpiresAt, (f, _) => f.Date.FutureOffset());
 
         public static readonly Faker<AccessRule> AccessRuleFaker = new Faker<AccessRule>() 

--- a/src/BasisTheory.net.Tests/Sessions/AuthorizeTests.cs
+++ b/src/BasisTheory.net.Tests/Sessions/AuthorizeTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BasisTheory.net.Common.Requests;
+using BasisTheory.net.Sessions;
+using BasisTheory.net.Tests.Sessions.Helpers;
+using Xunit;
+
+namespace BasisTheory.net.Tests.Sessions
+{
+    public class AuthorizeTests : IClassFixture<SessionFixture>
+    {
+        private readonly SessionFixture _fixture;
+        
+        public AuthorizeTests(SessionFixture fixture)
+        {
+            _fixture = fixture;
+        }
+        
+        public static IEnumerable<object[]> Methods
+        {
+            get
+            {
+                yield return new object []
+                {
+                    (Func<ISessionClient, AuthorizeSessionRequest, RequestOptions, Task>)(
+                        async (client, request, options) => await client.AuthorizeAsync(request, options)
+                    )
+                };
+                yield return new object []
+                {
+                    (Func<ISessionClient, AuthorizeSessionRequest, RequestOptions, Task>)(
+                        (client, request, options) => Task.Run(() => client.Authorize(request, options))
+                    )
+                };
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async Task ShouldAuthorize(Func<ISessionClient, AuthorizeSessionRequest, RequestOptions, Task> mut)
+        {
+            var request = new AuthorizeSessionRequest();
+            
+            HttpRequestMessage requestMessage = null;
+            _fixture.SetupHandler(HttpStatusCode.OK, null, (message, _) => requestMessage = message);
+
+            await mut(_fixture.Client, request, null);
+            
+            Assert.Equal(HttpMethod.Post, requestMessage.Method);
+            Assert.Equal("/sessions/authorize", requestMessage.RequestUri?.PathAndQuery);
+            Assert.Equal(_fixture.ApiKey, requestMessage.Headers.GetValues("BT-API-KEY").First());
+            _fixture.AssertUserAgent(requestMessage);
+        }
+    }
+}

--- a/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
+++ b/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BasisTheory.net.Common.Requests;
+using BasisTheory.net.Sessions;
+using BasisTheory.net.Tests.Sessions.Helpers;
+using BasisTheory.net.Tokens.Entities;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BasisTheory.net.Tests.Sessions
+{
+    public class CreateTests : IClassFixture<SessionFixture>
+    {
+        private readonly SessionFixture _fixture;
+        
+        public CreateTests(SessionFixture fixture)
+        {
+            _fixture = fixture;
+        }
+        
+        public static IEnumerable<object[]> Methods
+        {
+            get
+            {
+                yield return new object []
+                {
+                    (Func<ISessionClient, RequestOptions, Task<CreateSessionResponse>>)(
+                        async (client, options) => await client.CreateAsync(options)
+                    )
+                };
+                yield return new object []
+                {
+                    (Func<ISessionClient, RequestOptions, Task<CreateSessionResponse>>)(
+                        (client, options) => Task.FromResult(client.Create(options))
+                    )
+                };
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async Task ShouldCreate(Func<ISessionClient, RequestOptions, Task<CreateSessionResponse>> mut)
+        {
+            var content = new CreateSessionResponse();
+            var expectedSerialized = JsonConvert.SerializeObject(content);
+            
+            HttpRequestMessage requestMessage = null;
+            _fixture.SetupHandler(HttpStatusCode.Created, expectedSerialized, (message, _) => requestMessage = message);
+
+            var response = await mut(_fixture.Client, null);
+
+            Assert.Equal(expectedSerialized, JsonConvert.SerializeObject(response));
+            Assert.Equal(HttpMethod.Post, requestMessage.Method);
+            Assert.Equal("/sessions", requestMessage.RequestUri?.PathAndQuery);
+            Assert.Equal(_fixture.ApiKey, requestMessage.Headers.GetValues("BT-API-KEY").First());
+            _fixture.AssertUserAgent(requestMessage);
+        }
+    }
+}

--- a/src/BasisTheory.net.Tests/Sessions/Helpers/SessionFixture.cs
+++ b/src/BasisTheory.net.Tests/Sessions/Helpers/SessionFixture.cs
@@ -1,0 +1,15 @@
+using BasisTheory.net.Sessions;
+using BasisTheory.net.Tests.Helpers;
+
+namespace BasisTheory.net.Tests.Sessions.Helpers
+{
+    public class SessionFixture : BaseFixture
+    {
+        public readonly ISessionClient Client;
+
+        public SessionFixture()
+        {
+            Client = new SessionClient(ApiKey, HttpClient, appInfo: AppInfo);
+        }
+    }
+}

--- a/src/BasisTheory.net/Applications/Entities/Application.cs
+++ b/src/BasisTheory.net/Applications/Entities/Application.cs
@@ -42,11 +42,7 @@ namespace BasisTheory.net.Applications.Entities
         [JsonProperty("modified_at")]
         [JsonPropertyName("modified_at")]
         public DateTimeOffset? ModifiedDate { get; set; }
-        
-        [JsonProperty("can_create_expiring_applications")]
-        [JsonPropertyName("can_create_expiring_applications")]
-        public bool? CanCreateExpiringApplications { get; set; }
-        
+
         [JsonProperty("expires_at")]
         [JsonPropertyName("expires_at")]
         public DateTimeOffset? ExpiresAt { get; set; }

--- a/src/BasisTheory.net/Sessions/Entities/CreateSessionResponse.cs
+++ b/src/BasisTheory.net/Sessions/Entities/CreateSessionResponse.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
+namespace BasisTheory.net.Tokens.Entities
+{
+    public class CreateSessionResponse
+    {
+        [JsonProperty("session_key")]
+        [JsonPropertyName("session_key")]
+        public string SessionKey { get; set; }
+        
+        [JsonProperty("nonce")]
+        [JsonPropertyName("nonce")]
+        public string Nonce { get; set; }
+        
+        [JsonProperty("expires_at")]
+        [JsonPropertyName("expires_at")]
+        public DateTimeOffset? ExpiresAt { get; set; }
+    }
+}

--- a/src/BasisTheory.net/Sessions/Requests/AuthorizeSessionRequest.cs
+++ b/src/BasisTheory.net/Sessions/Requests/AuthorizeSessionRequest.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BasisTheory.net.Applications.Entities;
+using Newtonsoft.Json;
+
+public class AuthorizeSessionRequest
+{
+    [JsonProperty("nonce")]
+    [JsonPropertyName("nonce")]
+    public string Nonce { get; set; }
+
+    [JsonProperty("expires_at")]
+    [JsonPropertyName("expires_at")]
+    public DateTimeOffset? ExpiresAt { get; set; }
+        
+    [JsonProperty("permissions")]
+    [JsonPropertyName("permissions")]
+    public List<string>? Permissions { get; set; }
+        
+    [JsonProperty("rules")]
+    [JsonPropertyName("rules")]
+    public List<AccessRule>? Rules { get; set; }
+}

--- a/src/BasisTheory.net/Sessions/SessionClient.cs
+++ b/src/BasisTheory.net/Sessions/SessionClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BasisTheory.net.Common;
+using BasisTheory.net.Common.Entities;
+using BasisTheory.net.Common.Requests;
+using BasisTheory.net.Tokens.Entities;
+
+namespace BasisTheory.net.Sessions
+{
+    public interface ISessionClient
+    {
+        CreateSessionResponse Create(RequestOptions requestOptions = null);
+
+        Task<CreateSessionResponse> CreateAsync(
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default);
+        
+        void Authorize(AuthorizeSessionRequest authorizeSessionRequest, RequestOptions requestOptions = null);
+
+        Task AuthorizeAsync(
+            AuthorizeSessionRequest authorizeSessionRequest,
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default);
+    }
+    
+    public class SessionClient : BaseClient, ISessionClient
+    {
+        protected override string BasePath => "sessions";
+        
+        public SessionClient(
+            string apiKey = null,
+            HttpClient httpClient = null,
+            string apiBase = DefaultBaseUrl,
+            ApplicationInfo appInfo = null) :
+            base(apiKey, httpClient, apiBase, appInfo)
+        {
+        }
+        
+        public CreateSessionResponse Create(RequestOptions requestOptions = null)
+        {
+            return Post<CreateSessionResponse>(BasePath, null, requestOptions);
+        }
+
+        public async Task<CreateSessionResponse> CreateAsync(
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await PostAsync<CreateSessionResponse>(BasePath, null, requestOptions, cancellationToken);
+        }
+        
+        public void Authorize(AuthorizeSessionRequest authorizeSessionRequest, RequestOptions requestOptions = null)
+        {
+            Post($"{BasePath}/authorize", authorizeSessionRequest, requestOptions);
+        }
+
+        public async Task AuthorizeAsync(
+            AuthorizeSessionRequest authorizeSessionRequest,
+            RequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            await PostAsync($"{BasePath}/authorize", authorizeSessionRequest, requestOptions, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

This adds support for sessions in the dotnet SDK, & remove the `CanCreateExpiringApplications` property from Applications

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
