### PR TITLE
fix: Fixes namespace on CreateSessionResponse

### DIFF
--- a/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
+++ b/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using BasisTheory.net.Common.Requests;
 using BasisTheory.net.Sessions;
+using BasisTheory.net.Sessions.Entities;
 using BasisTheory.net.Tests.Sessions.Helpers;
 using BasisTheory.net.Tokens.Entities;
 using Newtonsoft.Json;

--- a/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
+++ b/src/BasisTheory.net.Tests/Sessions/CreateTests.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using BasisTheory.net.Common.Requests;
 using BasisTheory.net.Sessions;
-using BasisTheory.net.Sessions.Entities;
+using BasisTheory.net.Sessions.Responses;
 using BasisTheory.net.Tests.Sessions.Helpers;
 using BasisTheory.net.Tokens.Entities;
 using Newtonsoft.Json;

--- a/src/BasisTheory.net/Sessions/Entities/CreateSessionResponse.cs
+++ b/src/BasisTheory.net/Sessions/Entities/CreateSessionResponse.cs
@@ -2,7 +2,7 @@ using System;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
-namespace BasisTheory.net.Tokens.Entities
+namespace BasisTheory.net.Sessions.Entities
 {
     public class CreateSessionResponse
     {

--- a/src/BasisTheory.net/Sessions/Responses/CreateSessionResponse.cs
+++ b/src/BasisTheory.net/Sessions/Responses/CreateSessionResponse.cs
@@ -2,7 +2,7 @@ using System;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
-namespace BasisTheory.net.Sessions.Entities
+namespace BasisTheory.net.Sessions.Responses
 {
     public class CreateSessionResponse
     {

--- a/src/BasisTheory.net/Sessions/SessionClient.cs
+++ b/src/BasisTheory.net/Sessions/SessionClient.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using BasisTheory.net.Common;
 using BasisTheory.net.Common.Entities;
 using BasisTheory.net.Common.Requests;
-using BasisTheory.net.Sessions.Entities;
+using BasisTheory.net.Sessions.Responses;
 using BasisTheory.net.Sessions.Requests;
 using BasisTheory.net.Tokens.Entities;
 

--- a/src/BasisTheory.net/Sessions/SessionClient.cs
+++ b/src/BasisTheory.net/Sessions/SessionClient.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using BasisTheory.net.Common;
 using BasisTheory.net.Common.Entities;
 using BasisTheory.net.Common.Requests;
+using BasisTheory.net.Sessions.Entities;
 using BasisTheory.net.Sessions.Requests;
 using BasisTheory.net.Tokens.Entities;
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Updates namespace on `CreateSessionResponse` to `BasisTheory.net.Sessions.Responses`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
